### PR TITLE
Unifying some plots styles between NMR and UV-Vis

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @ml-evs @BenjaminCharmes @be-smith

--- a/src/datalab_app_plugin_insitu/apps/nmr/blocks.py
+++ b/src/datalab_app_plugin_insitu/apps/nmr/blocks.py
@@ -6,6 +6,7 @@ from typing import List
 import numpy as np
 from pydatalab.blocks.base import DataBlock
 
+from datalab_app_plugin_insitu._version import __version__
 from datalab_app_plugin_insitu.plotting import create_linked_insitu_plots, prepare_plot_data
 
 from .nmr_insitu import process_local_data
@@ -26,12 +27,9 @@ class InsituBlock(DataBlock):
     blocktype = "insitu-nmr"
     name = "NMR insitu"
     description = __doc__
+    version: str = __version__
 
     accepted_file_extensions = (".zip",)
-    available_folders: List[str] = []
-    nmr_folder_name = ""
-    echem_folder_name = ""
-    folder_name = ""
 
     defaults = {
         "ppm1": 0.0,
@@ -196,7 +194,7 @@ class InsituBlock(DataBlock):
         self.data["processing_params"]["ppm1"] = float(self.data.get("ppm1", self.defaults["ppm1"]))
         self.data["processing_params"]["ppm2"] = float(self.data.get("ppm2", self.defaults["ppm2"]))
 
-        if "nmr_data" not in self.data:
+        if not nmr_data:
             raise ValueError("No NMR data available after processing")
 
         plot_data = prepare_plot_data(nmr_data, echem_data, self.data["metadata"])

--- a/src/datalab_app_plugin_insitu/apps/nmr/blocks.py
+++ b/src/datalab_app_plugin_insitu/apps/nmr/blocks.py
@@ -36,7 +36,7 @@ class InsituBlock(DataBlock):
         "ppm2": 0.0,
         "start_exp": 1,
         "end_exp": None,
-        "step_exp": 1,
+        "step_exp": None,
         "exclude_exp": None,
     }
 
@@ -99,7 +99,7 @@ class InsituBlock(DataBlock):
         end_exp = self.data.get("end_exp", self.defaults["end_exp"])
         if end_exp is not None:
             end_exp = int(end_exp)
-        step_exp = int(self.data.get("step_exp", self.defaults["step_exp"]))
+        step_exp = self.data.get("step_exp", self.defaults["step_exp"])
         exclude_exp = self.data.get("exclude_exp", self.defaults["exclude_exp"])
 
         try:

--- a/src/datalab_app_plugin_insitu/apps/nmr/nmr_insitu.py
+++ b/src/datalab_app_plugin_insitu/apps/nmr/nmr_insitu.py
@@ -13,7 +13,7 @@ def process_local_data(
     echem_folder_name: str,
     start_at: int = 1,
     end_at: Optional[int] = None,
-    step: int = 1,
+    step: Optional[int] = None,
     exclude_exp: Optional[List[int]] = None,
 ) -> Dict:
     """
@@ -80,7 +80,7 @@ def process_datalab_data(
     echem_folder_name: str,
     start_at: int = 1,
     end_at: Optional[int] = None,
-    step: int = 1,
+    step: Optional[int] = None,
     exclude_exp: Optional[List[int]] = None,
 ) -> Dict:
     """

--- a/src/datalab_app_plugin_insitu/apps/nmr/utils.py
+++ b/src/datalab_app_plugin_insitu/apps/nmr/utils.py
@@ -112,7 +112,7 @@ def setup_bruker_paths(
     nmr_folder_path: Path,
     start_at: int,
     end_at: Optional[int] = None,
-    step: int = 1,
+    step: Optional[int] = None,
     exclude_exp: Optional[List[int]] = None,
 ) -> Tuple[List[str], List[str]]:
     """Setup experiment paths within the Bruker project and create output directory."""
@@ -127,6 +127,10 @@ def setup_bruker_paths(
 
     end_at = end_at if end_at is not None else max_exp
     end_at = min(end_at, max_exp)
+
+    if step is None:
+        # aim for a default of ~50 experiments
+        step = max(1, (end_at - start_at + 1) // 50)
 
     if step < 1:
         raise ValueError(f"step_exp must be >= 1, got {step}")
@@ -355,7 +359,7 @@ def _process_data(
     echem_folder_name: str,
     start_at: int,
     end_at: Optional[int] = None,
-    step: int = 1,
+    step: Optional[int] = None,
     exclude_exp: Optional[List[int]] = None,
 ) -> Dict:
     """
@@ -366,6 +370,8 @@ def _process_data(
         nmr_folder_path: Path to the NMR data folder
         echem_folder_name: Name of the electrochemistry folder
         start_at: Starting experiment number
+        step: Desired step size for experiments, will default to keeping
+            ~50 experiments
         exclude_exp: List of experiment numbers to exclude
 
     Returns:

--- a/src/datalab_app_plugin_insitu/apps/nmr/utils.py
+++ b/src/datalab_app_plugin_insitu/apps/nmr/utils.py
@@ -108,14 +108,14 @@ def extract_date_from_acqus(path: str) -> Optional[datetime]:
     return None
 
 
-def setup_paths(
+def setup_bruker_paths(
     nmr_folder_path: Path,
     start_at: int,
     end_at: Optional[int] = None,
     step: int = 1,
     exclude_exp: Optional[List[int]] = None,
 ) -> Tuple[List[str], List[str]]:
-    """Setup experiment paths and create output directory."""
+    """Setup experiment paths within the Bruker project and create output directory."""
     exp_folders = [d for d in Path(nmr_folder_path).iterdir() if d.is_dir() and d.name.isdigit()]
 
     max_exp = len(exp_folders)
@@ -130,6 +130,9 @@ def setup_paths(
 
     if step < 1:
         raise ValueError(f"step_exp must be >= 1, got {step}")
+
+    if step > (end_at - start_at + 1):
+        step = end_at - start_at + 1
 
     if end_at < start_at:
         raise ValueError(f"end_exp ({end_at}) must be >= start_exp ({start_at})")
@@ -372,7 +375,7 @@ def _process_data(
         nmr_dimension = check_nmr_dimension(nmr_folder_path)
 
         if nmr_dimension == "1D":
-            spec_paths, acqu_paths = setup_paths(
+            spec_paths, acqu_paths = setup_bruker_paths(
                 nmr_folder_path, start_at, end_at, step, exclude_exp
             )
             time_points = process_time_data(acqu_paths)


### PR DESCRIPTION
Whilst not fully unifying the code, this PR ports some of the changes to the uvvis block in #51 to the NMR block. It also:

- adds a CODEOWNERS so we get pinged for review automatically
- changes the default NMR "step size" to target ~50 experiments
- removes the reprocessing step and never saves raw data in the database for NMR