### PR TITLE
Add prefers_async flag to insitu blocks

### DIFF
--- a/src/datalab_app_plugin_insitu/apps/nmr/blocks.py
+++ b/src/datalab_app_plugin_insitu/apps/nmr/blocks.py
@@ -27,6 +27,7 @@ class InsituBlock(DataBlock):
 
     blocktype = "insitu-nmr"
     name = "NMR insitu"
+    prefers_async = True
     description = __doc__
     version: str = __version__
 
@@ -196,7 +197,8 @@ class InsituBlock(DataBlock):
 
         file_path = Path(file_path)
         extension: str = file_path.suffix.lower()
-        if extension not in self.accepted_file_extensions:  # type: ignore[union-attr]
+        # type: ignore[union-attr]
+        if extension not in self.accepted_file_extensions:
             raise ValueError(
                 f"Unsupported file extension (must be one of {self.accepted_file_extensions})"
             )

--- a/src/datalab_app_plugin_insitu/apps/nmr/blocks.py
+++ b/src/datalab_app_plugin_insitu/apps/nmr/blocks.py
@@ -27,7 +27,7 @@ class InsituBlock(DataBlock):
 
     blocktype = "insitu-nmr"
     name = "NMR insitu"
-    prefers_async = True
+    _prefers_async = True
     description = __doc__
     version: str = __version__
 
@@ -197,8 +197,7 @@ class InsituBlock(DataBlock):
 
         file_path = Path(file_path)
         extension: str = file_path.suffix.lower()
-        # type: ignore[union-attr]
-        if extension not in self.accepted_file_extensions:
+        if extension not in self.accepted_file_extensions:  # type: ignore[union-attr]
             raise ValueError(
                 f"Unsupported file extension (must be one of {self.accepted_file_extensions})"
             )

--- a/src/datalab_app_plugin_insitu/apps/uvvis/blocks.py
+++ b/src/datalab_app_plugin_insitu/apps/uvvis/blocks.py
@@ -22,6 +22,7 @@ class UVVisInsituBlock(GenericInSituBlock):
 
     blocktype = "insitu-uvvis"
     name = "UV-Vis insitu"
+    prefers_async = True
     description = __doc__
     accepted_file_extensions = (".zip",)
     available_folders: List[str] = []

--- a/src/datalab_app_plugin_insitu/apps/uvvis/blocks.py
+++ b/src/datalab_app_plugin_insitu/apps/uvvis/blocks.py
@@ -22,7 +22,7 @@ class UVVisInsituBlock(GenericInSituBlock):
 
     blocktype = "insitu-uvvis"
     name = "UV-Vis insitu"
-    prefers_async = True
+    _prefers_async = True
     description = __doc__
     accepted_file_extensions = (".zip",)
     available_folders: List[str] = []

--- a/src/datalab_app_plugin_insitu/apps/xrd/blocks.py
+++ b/src/datalab_app_plugin_insitu/apps/xrd/blocks.py
@@ -24,6 +24,7 @@ class XRDInsituBlock(GenericInSituBlock):
 
     blocktype = "insitu-xrd"
     name = "XRD insitu"
+    prefers_async = True
     description = __doc__
     accepted_file_extensions = (".zip",)
     available_folders: List[str] = []
@@ -102,7 +103,8 @@ class XRDInsituBlock(GenericInSituBlock):
 
         start_exp = int(self.data.get("start_exp", self.defaults["start_exp"]))
         exclude_exp = self.data.get("exclude_exp", self.defaults["exclude_exp"])
-        glob_str = self.data.get("glob_str")  # Optional: if None, all files are used
+        # Optional: if None, all files are used
+        glob_str = self.data.get("glob_str")
 
         # Auto-add wildcards if user doesn't include them
         if glob_str and "*" not in glob_str:

--- a/src/datalab_app_plugin_insitu/apps/xrd/blocks.py
+++ b/src/datalab_app_plugin_insitu/apps/xrd/blocks.py
@@ -24,7 +24,7 @@ class XRDInsituBlock(GenericInSituBlock):
 
     blocktype = "insitu-xrd"
     name = "XRD insitu"
-    prefers_async = True
+    _prefers_async = True
     description = __doc__
     accepted_file_extensions = (".zip",)
     available_folders: List[str] = []
@@ -103,8 +103,7 @@ class XRDInsituBlock(GenericInSituBlock):
 
         start_exp = int(self.data.get("start_exp", self.defaults["start_exp"]))
         exclude_exp = self.data.get("exclude_exp", self.defaults["exclude_exp"])
-        # Optional: if None, all files are used
-        glob_str = self.data.get("glob_str")
+        glob_str = self.data.get("glob_str")  # Optional: if None, all files are used
 
         # Auto-add wildcards if user doesn't include them
         if glob_str and "*" not in glob_str:


### PR DESCRIPTION
Linked to [Add asynchronous data block processing #1491
](https://github.com/datalab-org/datalab/pull/1491)

async processing for computationally intensive insitu operations.
